### PR TITLE
Multicategory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # react-algoliasearch
 
 A simple react component to integrate the Algolia search engine in your application.
-You can configure your Algolia index, app Id and api Key by passing props to the component.
+You can configure your Algolia indices, app Id and api Key by passing props to the component.
 
 
 
@@ -22,7 +22,7 @@ import AgAutocomplete from 'react-algoliasearch'
           apiKey={"6be0576ff61c053d5f9a3225e2a90f76"}
           appId={"latency"}
           displayKey="name"
-          index={"contacts"}
+          indices={[{index: 'contacts'}]}
           inputId="input-search"
           placeholder="Search..."
         />
@@ -39,7 +39,7 @@ import AgAutocomplete from 'react-algoliasearch'
 - `displayKey` - For a given suggestion object, determines the string representation of it. This will be used when setting the value of the input control after a suggestion is selected.
 Can be either a key string or a function that transforms a suggestion object into a string. Defaults to value. (optional)
 - `keyName` - The key contained in your Algolia Dataset that you would like to use as result, default is `name`. (optional)
-- `index` - The Algolia index you want to connect. (required)
+- `indices` - Array of Algolia indices you want to connect. (required)
 - `inputId` - The Id of the generated input field. (required)
 - `placeholder` - The input's placeholder. (optional)
 - `hitsPerPage` - The number of results that your search will produce. Default is 10. (optional)

--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -27,7 +27,7 @@ export default class App extends React.Component {
           appId="latency"
           displayKey={this.displayKey}
           keyName="name"
-          index="contacts"
+          indices={[{index: 'contacts'}]}
           inputId="input-search"
           placeholder="Search..."
           selected={this.suggestionSelected}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-algoliasearch",
   "description": "A react component for algolia autocomplete",
-  "version": "1.3.2",
+  "version": "2.0.0",
   "scripts": {
     "start": "webpack-dev-server -d --inline --progress --colors",
     "test": "karma start",
@@ -92,9 +92,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "autocomplete.js": "^0.22.0",
     "algoliasearch": "^3.19.0",
-    "ramda": "^0.22.1"
+    "autocomplete.js": "^0.22.0",
+    "deep-assign": "^2.0.0"
   },
   "pre-push": []
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,84 +1,104 @@
 'use strict';
-import React, { Component, PropTypes } from 'react'
-import R from 'ramda'
+import React, { Component, PropTypes } from 'react';
+import deepAssign from 'deep-assign';
 
 export default class AgAutocomplete extends Component {
   constructor(props) {
-    super(props)
-
-    this.search = null
+    super(props);
+    this.search = null;
     this.state = {
       values: []
-    }
+    };
   }
 
   componentWillReceiveProps (nextProps) {
     if(this.search && this.props.defaultValue !== nextProps.defaultValue) {
-      this.search.autocomplete.setVal(nextProps.defaultValue)
+      this.search.autocomplete.setVal(nextProps.defaultValue);
     }
   }
 
   componentDidMount() {
     //this thing sucks but for now it must be like this or window will be undefined.
-    const algoliasearch = require('algoliasearch')
-    const autocomplete = require('autocomplete.js')
+    const algoliasearch = require('algoliasearch');
+    const autocomplete = require('autocomplete.js');
 
     const {
       appId,
       apiKey,
       hitsPerPage,
-      index,
+      indices,
       displayKey,
       options,
       inputId,
+      keyName,
+      currentLanguage,
       defaultValue
-    } = this.props
+    } = this.props;
 
-    const agClient = algoliasearch(appId, apiKey)
-    const agIndex  = agClient.initIndex(index)
+    const agClient = algoliasearch(appId, apiKey);
+    const indicesOptions = [];
 
-    const defaultOptions = {
-      source: function(q, cb) {
-        agIndex.search(q, { hitsPerPage: hitsPerPage || 10 }, (error, content) => {
-          if (error) {
-            cb([])
-            return
+    indices.map((item) => {
+      const {
+        index,
+        displayKey: itemDisplayKey,
+        hitsPerPage: itemHitsPerPage,
+        keyName: itemKeyName,
+        options: itemOptions
+      } = item;
+      const agIndex = agClient.initIndex(index);
+      const hitsLimit = itemHitsPerPage ? itemHitsPerPage : (hitsPerPage || 10);
+      const indexOptions = {
+        source: function(query, cb) {
+          agIndex.search(query, { hitsPerPage: hitsLimit })
+            .then(data => {
+              return cb(data.hits, data);
+            })
+            .catch(error => {
+              console.log(error);
+              return cb([]);
+            });
+        },
+        displayKey: itemDisplayKey ? itemDisplayKey : (displayKey || 'value'),
+        templates: {
+          suggestion: (suggestion) => {
+            const key = itemKeyName ? itemKeyName : (keyName || 'name');
+
+            if (currentLanguage) {
+              return suggestion._highlightResult[key][this.props.currentLanguage].value;
+            }
+            
+            return suggestion._highlightResult[key].value;
           }
-          cb(content.hits, content);
-        })
-      },
-      displayKey: displayKey || 'value',
-      templates: {
-        suggestion: (suggestion) => {
-          const key = this.props.keyName || 'name'
-          return this.props.currentLanguage ? suggestion._highlightResult[key][this.props.currentLanguage].value :  suggestion._highlightResult[key].value
         }
       }
-    }
+      const agOptions = deepAssign(indexOptions, options, itemOptions);
 
-    const agOptions = R.merge(defaultOptions, options)
-    this.search = autocomplete(`#${inputId}`, agOptions, [agOptions])
+      indicesOptions.push(agOptions);
+    })
+
+    this.search = autocomplete(`#${inputId}`, {}, indicesOptions);
 
     this.search
-    .on('autocomplete:opened', this.props.opened)
-    .on('autocomplete:shown', this.props.shown)
-    .on('autocomplete:closed', this.props.closed)
-    .on('autocomplete:updated', this.props.updated)
-    .on('autocomplete:cursorchanged', this.props.cursorchanged)
-    .on('autocomplete:selected', this.props.selected)
-    .on('autocomplete:autocompleted', this.props.autocompleted)
+      .on('autocomplete:opened', this.props.opened)
+      .on('autocomplete:shown', this.props.shown)
+      .on('autocomplete:closed', this.props.closed)
+      .on('autocomplete:updated', this.props.updated)
+      .on('autocomplete:cursorchanged', this.props.cursorchanged)
+      .on('autocomplete:selected', this.props.selected)
+      .on('autocomplete:autocompleted', this.props.autocompleted)
 
     defaultValue ? this.search.autocomplete.setVal(defaultValue) : false
   }
 
   render() {
-    const  { otherProps, placeholder, inputId } = this.props
-
+    const  { otherProps, placeholder, inputId } = this.props;
+    
     return (
       <input
-      id={inputId}
-      placeholder={placeholder || 'Enter a search term...'}
-      {...otherProps} />
+        id={inputId}
+        placeholder={placeholder || 'Enter a search term...'}
+        {...otherProps} />
     )
   }
 }
@@ -99,7 +119,7 @@ AgAutocomplete.propTypes = {
   appId: PropTypes.string.isRequired,
   currentLanguage: PropTypes.string,
   hitsPerPage: PropTypes.number,
-  index: PropTypes.string.isRequired,
+  indices: PropTypes.array.isRequired,
   inputId: PropTypes.string.isRequired,
   keyName: PropTypes.string,
   defaultValue: PropTypes.string,


### PR DESCRIPTION
Works fine for me with multiple categories (different keyName, templates and hitPerPage). 
Props flow is changed pretty much so I guess it should go with version 2.0.0
For single index search just pass one object in array.