### PR TITLE
Remove references to React.PropTypes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -137,8 +137,8 @@ AgAutocomplete.propTypes = {
   selected: PropTypes.func,
   autocompleted: PropTypes.func,
   placeholder: PropTypes.string,
-  displayKey: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.func
+  displayKey: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func
   ])
 }


### PR DESCRIPTION
Fixes some bad references in React 16. :)